### PR TITLE
Adding multi-page support when calling NewRelic API

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,10 @@ Open a graph in edit mode by click the *Title > Edit* (or by pressing *e* key wh
 
 - Use *Mixed* datasource if you're trying to superimpose metrics from different datasources.
 
+## A note on large result sets from New Relic
+New Relic APIs, by default, return 200 results (see https://docs.newrelic.com/docs/apis/rest-api-v2/requirements/pagination-api-output). Paging has been added to the query for Applications, with an arbitrary limit hardcoded at 10 pages.
+- The hardcoded limit is arbitrary. If you need more than 2000 results (200 per page over 10 pages), increasing the *finalPageNumber* default value in *NewRelicQueryCtrl.prototype.getApplications* is all that would need to be done.
+- Although paging has been implemented for Applications, the same can not yet be said for Metrics. This means that Metrics are currently limited to 200 results maximum.
+
 
 

--- a/dist/datasource.js
+++ b/dist/datasource.js
@@ -248,10 +248,13 @@ System.register(['moment'], function(exports_1) {
                     });
                 };
                 // Gets applications for query editor
-                NewRelicDatasource.prototype.getApplications = function () {
+                NewRelicDatasource.prototype.getApplications = function (pageNumber) {
+                    if (pageNumber == null) {
+                        pageNumber = 1;
+                    }
                     var self = this;
                     var request = {
-                        url: self.apiUrl + '/v2/applications.json'
+                        url: self.apiUrl + '/v2/applications.json?page=' + pageNumber
                     };
                     return this.makeRequest(request)
                         .then(function (result) {


### PR DESCRIPTION
This update supports when there is more than a single page of results to be returned from New Relic's API. This is needed when there are more than 200 results (200 being the maximum result size returned from the API, documented here: https://docs.newrelic.com/docs/apis/rest-api-v2/requirements/pagination-api-output).